### PR TITLE
Implemented multi-agent

### DIFF
--- a/backend/action.py
+++ b/backend/action.py
@@ -1,5 +1,4 @@
 from backend.predicate import Predicate
-import pygame
 
 class Action(object):
     """

--- a/backend/predicate.py
+++ b/backend/predicate.py
@@ -1,3 +1,5 @@
+from backend.object import Object
+
 class Predicate(object):
     '''
     This class represents a predicate in Robotouille. 
@@ -89,4 +91,7 @@ class Predicate(object):
             pred (Predicate): The copy of the predicate.
         """
         pred_args = [param_arg_dict[param.name] for param in self.params]
-        return Predicate().initialize(self.name, self.types, pred_args)
+        new_pred_args = []
+        for arg in pred_args:
+            new_pred_args.append(Object(arg.name, arg.object_type))
+        return Predicate().initialize(self.name, self.types, new_pred_args)

--- a/backend/special_effects/creation_effect.py
+++ b/backend/special_effects/creation_effect.py
@@ -1,4 +1,5 @@
 from backend.special_effect import SpecialEffect
+from backend.object import Object
 
 class CreationEffect(SpecialEffect):
     """
@@ -97,9 +98,13 @@ class CreationEffect(SpecialEffect):
         """
         if self.completed:
             return
-        state.add_object(self.created_obj[1])
+        new_obj = state.add_object(self.created_obj[1])
         for effect, value in self.effects.items():
+            for param in effect.params:
+                if param == self.created_obj[1]:
+                    param.name = new_obj.name
             state.update_predicate(effect, value)
         for special_effect in self.special_effects:
             special_effect.update(state, active)
-        self.completed = True
+        if all([special_effect.completed for special_effect in self.special_effects]):
+            self.completed = True

--- a/backend/state.py
+++ b/backend/state.py
@@ -398,9 +398,12 @@ class State(object):
         Steps the state forward by applying the effects of the action.
 
         Args:
-            actions (Dictionary[Action, Dictionary[Str, Object]]): A dictionary
-                of actions to perform. The keys are the actions, and the values
-                are the parameter-argument dictionaries for the actions.
+            actions (List[Tuple[Action, Dictionary[str, Object]]): A list of
+                tuples where the first element is the action to perform, and the
+                second element is a dictionary of arguments for the action. The 
+                length of the list is the number of players, where actions[i] is
+                the action for player i. If player i is not performing an action,
+                actions[i] is None.
         
         Returns:
             new_state (State): The successor state.
@@ -410,7 +413,9 @@ class State(object):
             AssertionError: If the action is invalid with the given arguments in
             the given state.
         """
-        for action, param_arg_dict in actions.items():
+        for action, param_arg_dict in actions:
+            if not action:
+                continue
             assert action.is_valid(self, param_arg_dict)
             self = action.perform_action(self, param_arg_dict)
         

--- a/backend/tests/test_envs.py
+++ b/backend/tests/test_envs.py
@@ -4,15 +4,22 @@ import subprocess
 
 ALL_TESTS = {
     'base tests':[
+        'base_add_to_soup',
+        'base_boil_water',
         'base_cook',
         'base_cut',
+        'base_fill_pot',
+        'base_fill_two_pots',
         'base_move',
+        'base_pickup_container',
         'base_pickup',
+        'base_place_container',
         'base_place',
         'base_stack',
         'base_unstack'
     ],
     'composite tests':[
+        'composite_add_fill_bowl',
         'composite_cook_pickup',
         'composite_cut_pickup',
         'composite_move_cook',
@@ -26,6 +33,7 @@ ALL_TESTS = {
     ],
     'high level tests':[
         'cook_patties',
+        'cook_soup',
         'cut_lettuces',
         'fry_chicken',
         'fry_potato',

--- a/domain/robotouille.json
+++ b/domain/robotouille.json
@@ -649,36 +649,50 @@
             "immediate_fx":[],
             "sfx": [
                 {
-                    "type": "delayed",
+                    "type": "conditional",
                     "param": "c1",
+                    "conditions": [
+                        {
+                            "predicate": "container_at",
+                            "params": ["c1", "s1"],
+                            "is_true": true
+                        }
+                    ],
                     "fx": [],
                     "sfx": [
                         {
-                            "type": "creation",
+                            "type": "delayed",
                             "param": "c1",
-                            "created_obj": {
-                                "name": "water",
-                                "type": "meal",
-                                "param": "m1"
-                            },
-                            "fx": [
+                            "fx": [],
+                            "sfx": [
                                 {
-                                    "predicate": "iswater",
-                                    "params": ["m1"],
-                                    "is_true": true
-                                },
-                                {
-                                    "predicate": "in",
-                                    "params": ["m1", "c1"],
-                                    "is_true": true
-                                },
-                                {
-                                    "predicate": "container_empty",
-                                    "params": ["c1"],
-                                    "is_true": false
+                                    "type": "creation",
+                                    "param": "c1",
+                                    "created_obj": {
+                                        "name": "water",
+                                        "type": "meal",
+                                        "param": "m1"
+                                    },
+                                    "fx": [
+                                        {
+                                            "predicate": "iswater",
+                                            "params": ["m1"],
+                                            "is_true": true
+                                        },
+                                        {
+                                            "predicate": "in",
+                                            "params": ["m1", "c1"],
+                                            "is_true": true
+                                        },
+                                        {
+                                            "predicate": "container_empty",
+                                            "params": ["c1"],
+                                            "is_true": false
+                                        }
+                                    ],
+                                    "sfx": []
                                 }
-                            ],
-                            "sfx": []
+                            ]
                         }
                     ]
                 }
@@ -779,6 +793,11 @@
                 {
                     "predicate": "loc",
                     "params": ["p1", "s1"],
+                    "is_true": true
+                },
+                {
+                    "predicate": "container_at",
+                    "params": ["c1", "s1"],
                     "is_true": true
                 },
                 {

--- a/environments/env_generator/builder.py
+++ b/environments/env_generator/builder.py
@@ -150,7 +150,8 @@ def build_station_location_predicates(environment_dict):
     """
     predicates_str = ""
     for station in environment_dict["stations"]:
-        for field in ["items", "players"]:
+        valid_fields = [field for field in ["items", "players"] if field in environment_dict]
+        for field in valid_fields:
             match = False
             no_match_predicate = "empty" if field == "items" else "vacant"
             predicate = "item_at" if field == "items" else "loc"
@@ -181,7 +182,7 @@ def build_player_location_predicates(environment_dict):
     predicates_str = ""
     for player in environment_dict["players"]:
         match = False
-        for item in environment_dict["items"]:
+        for item in environment_dict.get("items", []):
             if player["x"] == item["x"] and player["y"] == item["y"]:
                 predicates_str += f"    (has {player['name']} {item['name']})\n"
                 match = True
@@ -228,7 +229,7 @@ def build_stacking_predicates(environment_dict):
     stacks = {}
     # Sort items into stacks ordered by stacking order
     sorting_key = lambda item: item["stack-level"]
-    for item in environment_dict["items"]:
+    for item in environment_dict.get("items", []):
         for station in environment_dict["stations"]:
             if item["x"] == station["x"] and item["y"] == station["y"]:
                 stacks[station["name"]] = stacks.get(station["name"], []) + [item]
@@ -300,12 +301,13 @@ def create_unique_and_combination_preds(environment_dict):
                     # Get all entities to prepare the combination
                     arg_entities = list(filter(lambda entity: arg in entity["name"], environment_dict[entity_field]))
                     arg_entity_names = list(map(lambda entity: entity["name"], arg_entities))
-                    combination_dict[arg]['entities'] = arg_entity_names
+                    combination_dict[arg]['entities'] = arg_entity_names if arg_entity_names else []
                     combination_dict[arg]['ids'] = set()
                 combination_dict[arg]['ids'].add(arg_id)
             else:
                 # Unique predicate
                 same_id_entity = list(filter(lambda entity: entity.get("id") == arg_id, environment_dict[entity_field]))
+                # If the entity is not found, then it is a wild card entity
                 entity_name = same_id_entity[0]["name"]
                 pred.append(entity_name)
         if unique_pred:
@@ -335,6 +337,9 @@ def create_combinations(combination_dict):
         ids = list(combination_dict[arg]['ids'])
         id_order += ids
         entities = combination_dict[arg]['entities']
+        if entities == []:
+            for id in ids:
+                entities.append(arg + id)
         permutations = list(itertools.permutations(entities, len(ids)))
         combination_list.append(permutations)
     product = itertools.product(*combination_list)
@@ -376,7 +381,7 @@ def build_goal(environment_dict):
     goal =  "   (or\n"
     unique_preds, combination_preds, combination_dict = create_unique_and_combination_preds(environment_dict)
     combinations, id_order = create_combinations(combination_dict)
-    assert len(combinations) > 0, "Object in goal missing from environment"
+    # assert len(combinations) > 0, "Object in goal missing from environment"
     for combination in combinations:
         # Combination predicates with the combination ID arguments filled in
         filled_combination_preds = copy.deepcopy(combination_preds)

--- a/environments/env_generator/examples/base_fill_pot.json
+++ b/environments/env_generator/examples/base_fill_pot.json
@@ -14,21 +14,13 @@
     },
     "stations": [
         {
-            "name": "stove",
+            "name": "sink",
             "x": 0,
             "y": 1,
             "id": "A"
         }
     ],
-    "items": [
-        {
-            "name": "tomato",
-            "x": 0,
-            "y": 0,
-            "id": "c",
-            "predicates": ["iscut"]
-        }
-    ],
+    "items": [],
     "players": [
         {
             "name": "robot",
@@ -37,28 +29,21 @@
             "direction": [0, 1]
         }
     ],
-    "meals": [
-        {
-            "name": "water",
-            "x": 0,
-            "y": 1,
-            "id": "b",
-            "predicates": ["isboiling"]
-        }
-    ],
+    "meals": [],
     "containers": [
         {
             "name": "pot",
             "x": 0,
             "y": 1,
-            "id": "a"
+            "id": "a",
+            "meal_id": []
         }
     ],
     "goal": [
         {
-            "predicate": "addedto",
-            "args": ["tomato", "water"],
-            "ids": ["c", "b"]
+            "predicate": "in",
+            "args": ["water", "pot"],
+            "ids": [1, 2]
         }
     ]
 }

--- a/environments/env_generator/examples/base_fill_two_pots.json
+++ b/environments/env_generator/examples/base_fill_two_pots.json
@@ -18,6 +18,12 @@
             "x": 0,
             "y": 1,
             "id": "A"
+        },
+        {
+            "name": "sink",
+            "x": 2,
+            "y": 1,
+            "id": "B"
         }
     ],
     "items": [],
@@ -37,13 +43,25 @@
             "y": 1,
             "id": "a",
             "meal_id": []
+        },
+        {
+            "name": "pot",
+            "x": 2,
+            "y": 1,
+            "id": "b",
+            "meal_id": []
         }
     ],
     "goal": [
         {
-            "predicate": "isbowl",
-            "args": ["pot"],
-            "ids": ["a"]
+            "predicate": "in",
+            "args": ["water", "pot"],
+            "ids": [1, "a"]
+        },
+        {
+            "predicate": "in",
+            "args": ["water", "pot"],
+            "ids": [2, 3]
         }
     ]
 }

--- a/environments/env_generator/examples/composite_add_fill_bowl.json
+++ b/environments/env_generator/examples/composite_add_fill_bowl.json
@@ -67,9 +67,14 @@
     ],
     "goal": [
         {
-            "predicate": "iscooked",
-            "args": ["patty"],
-            "ids": ["a"]
+            "predicate": "addedto",
+            "args": ["tomato", "water"],
+            "ids": ["a", "b"]
+        },
+        {
+            "predicate": "in",
+            "args": ["water", "bowl"],
+            "ids": ["b", "d"]
         }
     ]
 }

--- a/environments/env_generator/examples/cook_soup.json
+++ b/environments/env_generator/examples/cook_soup.json
@@ -84,6 +84,12 @@
             "x": 0,
             "y": 0,
             "direction": [0, 1]
+        },
+        {
+            "name": "robot",
+            "x": 1,
+            "y": 0,
+            "direction": [0, 1]
         }
     ],
     "goal_description": "",

--- a/environments/env_generator/examples/cook_soup.json
+++ b/environments/env_generator/examples/cook_soup.json
@@ -75,7 +75,8 @@
         {
             "name": "bowl",
             "x": 0,
-            "y": 3
+            "y": 3,
+            "id": "b"
         }
     ],
     "players": [
@@ -95,9 +96,14 @@
     "goal_description": "",
     "goal": [
         {
-            "predicate": "isbowl",
-            "args": ["pot"],
-            "ids": ["a"]
+            "predicate": "in",
+            "args": ["water", "bowl"],
+            "ids": [1, "b"]
+        },
+        {
+            "predicate": "addedto",
+            "args": ["tomato", "water"],
+            "ids": [2, 1]
         }
     ]
 }

--- a/renderer/renderer.py
+++ b/renderer/renderer.py
@@ -27,7 +27,7 @@ class RobotouilleRenderer:
         with open(os.path.join(CONFIG_DIR, config_filename), "r") as f:
             config = json.load(f)
         # The canvas is responsible for drawing the game state on a pygame surface.
-        self.canvas = RobotouilleCanvas(config, layout, players[0], window_size)
+        self.canvas = RobotouilleCanvas(config, layout, players, window_size)
         # The pygame window size.
         self.window_size = window_size
         # The framerate of the renderer. This isn't too important since the renderer

--- a/robotouille/env.py
+++ b/robotouille/env.py
@@ -85,24 +85,34 @@ def build_station_location_predicates(environment_dict):
     for station in environment_dict["stations"]:
         station_obj = Object(station["name"], "station")
         match = False
-        for field in ["players", "items", "containers"]:
-            if not environment_dict.get(field): continue
-            no_match_predicate = "station_empty" if field in ["items", "containers"] else "vacant"
-            predicate = "item_at" if field == "items" else "container_at" if field == "containers" else "loc"
-            for entity in environment_dict[field]:
-                x = entity["x"] + entity["direction"][0] if field == "players" else entity["x"]
-                y = entity["y"] + entity["direction"][1] if field == "players" else entity["y"]
+        # Check if there are any players at the station
+        for player in environment_dict.get("players", []):
+            x = player["x"] + player["direction"][0]
+            y = player["y"] + player["direction"][1]
+            if x == station["x"] and y == station["y"]:
+                name = player["name"]
+                obj = Object(name, "player")
+                pred = Predicate().initialize("loc", ["player", "station"], [obj, station_obj])
+                predicates.append(pred)
+                match = True
+        # If no players are at the station, add a vacant predicate
+        if not match:
+            pred = Predicate().initialize("vacant", ["station"], [station_obj])
+            predicates.append(pred)
+        match = False
+        # Check if there are any items or containers at the station
+        for field in ["items", "containers"]:
+            predicate = "item_at" if field == "items" else "container_at"
+            for entity in environment_dict.get(field, []):
+                x = entity["x"]
+                y = entity["y"]
                 if x == station["x"] and y == station["y"]:
                     name = entity["name"]
                     obj = Object(name, field[:-1])
                     pred = Predicate().initialize(predicate, [field[:-1], "station"], [obj, station_obj])
                     predicates.append(pred)
                     match = True
-            if field == "players":
-                if not match:
-                    pred = Predicate().initialize(no_match_predicate, ["station"], [station_obj])
-                    predicates.append(pred)
-                else: match = False
+        # If no items or containers are at the station, add a station_empty predicate
         if not match:
             pred = Predicate().initialize("station_empty", ["station"], [station_obj])
             predicates.append(pred)
@@ -252,7 +262,7 @@ def build_goal(environment_dict):
     goal =  []
     unique_preds, combination_preds, combination_dict = create_unique_and_combination_preds(environment_dict)
     combinations, id_order = create_combinations(combination_dict)
-    assert len(combinations) > 0, "Object in goal missing from environment"
+    # assert len(combinations) > 0, "Object in goal missing from environment"
     for combination in combinations:
         # Combination predicates with the combination ID arguments filled in
         filled_combination_preds = copy.deepcopy(combination_preds)

--- a/robotouille/robotouille_env.py
+++ b/robotouille/robotouille_env.py
@@ -74,9 +74,9 @@ def create_robotouille_env(problem_filename, seed=None, noisy_randomization=Fals
         environment_json = _procedurally_generate(environment_json, int(seed), noisy_randomization)
     layout = _parse_renderer_layout(environment_json)
     config_filename = "robotouille_config.json"
+    problem_string, environment_json = builder.build_problem(environment_json) # IDs objects in environment
     renderer = RobotouilleRenderer(config_filename=config_filename, layout=layout, players=environment_json["players"])
     render_fn = renderer.render
-    problem_string, environment_json = builder.build_problem(environment_json) # IDs objects in environment
     domain_filename = "domain/robotouille.json"
     with open(domain_filename, "r") as domain_file:
         domain_json = json.load(domain_file)

--- a/robotouille/robotouille_simulator.py
+++ b/robotouille/robotouille_simulator.py
@@ -18,10 +18,16 @@ def simulator(environment_name: str, seed: int=42, noisy_randomization: bool=Fal
         mousedown_events = list(filter(lambda e: e.type == pygame.MOUSEBUTTONDOWN, pygame_events))
         # Keyboard events ('e' button) for cut/cook ('space' button) for noop
         keydown_events = list(filter(lambda e: e.type == pygame.KEYDOWN, pygame_events))
+        actions = []
         action, args = create_action_from_control(env, obs, obs.current_player, mousedown_events+keydown_events, renderer)
+        for player in obs.get_players():
+            if player == obs.current_player:
+                actions.append((action, args))
+            else:
+                actions.append((None, None))
         if not interactive and action is None:
             # Retry for keyboard input
             continue
-        obs, reward, done, info = env.step(actions={action: args}, interactive=interactive)
+        obs, reward, done, info = env.step(actions, interactive=interactive)
         renderer.render(obs, mode='human')
     renderer.render(obs, close=True)

--- a/robotouille/robotouille_simulator.py
+++ b/robotouille/robotouille_simulator.py
@@ -10,7 +10,7 @@ def simulator(environment_name: str, seed: int=42, noisy_randomization: bool=Fal
     renderer.render(obs, mode='human')
     done = False
     interactive = False # Set to True to interact with the environment through terminal REPL (ignores input)
-
+    
     while not done:
         # Construct action from input
         pygame_events = pygame.event.get()
@@ -18,10 +18,10 @@ def simulator(environment_name: str, seed: int=42, noisy_randomization: bool=Fal
         mousedown_events = list(filter(lambda e: e.type == pygame.MOUSEBUTTONDOWN, pygame_events))
         # Keyboard events ('e' button) for cut/cook ('space' button) for noop
         keydown_events = list(filter(lambda e: e.type == pygame.KEYDOWN, pygame_events))
-        action, args = create_action_from_control(env, obs, mousedown_events+keydown_events, renderer)
+        action, args = create_action_from_control(env, obs, obs.current_player, mousedown_events+keydown_events, renderer)
         if not interactive and action is None:
             # Retry for keyboard input
             continue
-        obs, reward, done, info = env.step(action=action, args=args, interactive=interactive)
+        obs, reward, done, info = env.step(actions={action: args}, interactive=interactive)
         renderer.render(obs, mode='human')
     renderer.render(obs, close=True)

--- a/utils/robotouille_input.py
+++ b/utils/robotouille_input.py
@@ -1,6 +1,6 @@
 import pygame
 
-def create_action_from_control(env, obs, action, renderer):
+def create_action_from_control(env, obs, player, action, renderer):
     """
     This function attempts to create a valid action from the provided action.
 
@@ -14,6 +14,7 @@ def create_action_from_control(env, obs, action, renderer):
     Args:
         env: The environment.
         obs: The current observation.
+        player: The player to control.
         action: The action to transform.
         renderer: The renderer.
     
@@ -23,12 +24,12 @@ def create_action_from_control(env, obs, action, renderer):
             arguments for the action.
     """
     if len(action) == 0: return None, None
-    valid_actions = obs.get_valid_actions()
+    valid_actions = obs.get_valid_actions_for_player(player)
     action_dict = {str(action): action for action in env.action_space}
     input_json = env.input_json
     action = action[0]
     for literal, is_true in obs.predicates.items():
-        if literal.name == "loc" and is_true:
+        if literal.name == "loc" and is_true and literal.params[0].name == player.name:
             player_loc = str(literal.params[1])
     if action.type == pygame.MOUSEBUTTONDOWN:
         pos_x, pos_y = action.pos


### PR DESCRIPTION
## Overview

In this PR, I implement multiagents. Now, Robotouille is able to render and play with multiple players. Currently, actions are turn-based. The state keeps track of which player should make a turn at each point. After a player makes an action, its effects are applied to the state, and the current player is updated to the next player. The next player can then perform an action, and so on. 


## Changes Made

- Added new field current_player to state.py to keep track of which player is currently playing
- Added new methods to get the valid actions of a single player and process the next player to play
- Pass in actions as a dictionary of actions as keys and arguments as values to the step functions in env.py and state.py
- RobotouilleCanvas and RobotouilleRenderer now keep track of all players in the game state and render them accordingly
- Updated robotouille_simulator.py and robotouille_env.py to account for multiple players
- Updated robotouille_input.py to look for actions only for a specific player


## Test Coverage

Tested manually using cook_soup.py